### PR TITLE
Fix session and request management errors

### DIFF
--- a/task_skill_swap-main/templates/skill_sessions/my_sessions.html
+++ b/task_skill_swap-main/templates/skill_sessions/my_sessions.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load session_tags %}
 
 {% block title %}My Sessions{% endblock %}
 

--- a/task_skill_swap-main/templates/skill_sessions/session_requests_management.html
+++ b/task_skill_swap-main/templates/skill_sessions/session_requests_management.html
@@ -263,7 +263,7 @@
                                                 <i class="fas fa-times mr-2"></i>Cancel
                                             </button>
                                         {% elif request.status == 'accepted' %}
-                                            <a href="{% url 'skill_sessions:view_session' request.session.id %}" 
+                                            <a href="{% url 'skill_sessions:session_detail' request.session.id %}" 
                                                class="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition duration-200 font-semibold">
                                                 <i class="fas fa-calendar-check mr-2"></i>View Session
                                             </a>

--- a/task_skill_swap-main/templates/skills/find_tutors.html
+++ b/task_skill_swap-main/templates/skills/find_tutors.html
@@ -81,9 +81,9 @@
                             <i class="fas fa-user mr-2"></i>View Full Profile
                         </a>
                         {% if user.is_authenticated and user != tutor.user %}
-                            <button onclick="requestTutor({{ tutor.user.id }}, '{{ tutor.user.first_name|default:tutor.user.username }}')" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg text-center hover:bg-green-700 transition-colors">
+                            <a href="{% url 'skill_sessions:create_request' %}?recipient={{ tutor.user.id }}" class="w-full bg-green-600 text-white py-2 px-4 rounded-lg text-center hover:bg-green-700 transition-colors block">
                                 <i class="fas fa-paper-plane mr-2"></i>Send Request
-                            </button>
+                            </a>
                         {% endif %}
                     </div>
                 </div>

--- a/task_skill_swap-main/templates/skills/tutor_profile.html
+++ b/task_skill_swap-main/templates/skills/tutor_profile.html
@@ -106,15 +106,7 @@
                     </div>
                 </div>
                 
-                {% if user.is_authenticated and user != tutor %}
-                <div class="bg-white rounded-xl shadow-lg p-8 text-center">
-                    <h2 class="text-2xl font-bold text-gray-800 mb-4">Ready to Learn?</h2>
-                    <p class="text-gray-600 mb-6">Connect with {{ tutor.first_name|default:tutor.username }} to start your learning journey!</p>
-                    <button onclick="requestGeneral({{ tutor.id }}, '{{ tutor.first_name|default:tutor.username }}')" class="bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-8 rounded-lg text-lg font-semibold hover:from-blue-700 hover:to-purple-700 transition-all transform hover:scale-105 shadow-lg">
-                        <i class="fas fa-paper-plane mr-2"></i>Send General Request
-                    </button>
-                </div>
-                {% endif %}
+
             {% else %}
                 <div class="bg-white rounded-xl shadow-lg p-12 text-center">
                     <i class="fas fa-info-circle text-gray-400 text-6xl mb-6"></i>


### PR DESCRIPTION
Resolves several reported bugs related to template rendering, URL routing, and view logic across session and skill modules.

This PR addresses the following issues:
*   Enabled `session_format_icon` filter by loading `session_tags` in `my_sessions.html`.
*   Removed the "Ready to Learn" section from `tutor_profile.html`.
*   Updated "Send Request" buttons in `find_tutors.html` to directly link to the request creation form.
*   Modified `RequestDetailView` to redirect to the associated user's profile instead of a missing template.
*   Corrected the `NoReverseMatch` error by changing `view_session` to `session_detail` in `session_requests_management.html`.
*   Enhanced `SessionDetailView` to correctly handle both `pk` and `session_id` URL parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff8bba2d-2442-4281-8d9e-33e3263c70c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff8bba2d-2442-4281-8d9e-33e3263c70c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>